### PR TITLE
Update exits.py with changes to max_hold_long and max_hold_short functions

### DIFF
--- a/qnt/exits.py
+++ b/qnt/exits.py
@@ -92,6 +92,7 @@ def max_hold_long(weights, state, max_period):
     prev_pos = weights.isel(time=-2)
 
     holding_time_prev = state['holding_time']
+    holding_time_prev = holding_time_prev.reindex_like(curr_pos, fill_value=0)
 
     reset_or_increase = xr.where(holding_time_prev >= max_period, 0, holding_time_prev + 1)
 
@@ -110,6 +111,7 @@ def max_hold_short(weights, state, max_period):
     prev_pos = weights.isel(time=-2)
 
     holding_time_prev = state['holding_time']
+    holding_time_prev = holding_time_prev.reindex_like(curr_pos, fill_value=0)
 
     reset_or_increase = xr.where(holding_time_prev >= max_period, 0, holding_time_prev + 1)
     holding_time = xr.where(curr_pos < 0, reset_or_increase, holding_time_prev)


### PR DESCRIPTION
Changed max_hold_long and max_hold_short functions in exits.py to correct the case when symbol exists in curr_pos and don't in holding_time_prev. This  happens when during processing there is a company that  never before was in index and now is in index membership.