### PR TITLE
⚡️ Speed up function `get_annual_indicator_names` by 33%

### DIFF
--- a/qnt/data/secgov_fundamental.py
+++ b/qnt/data/secgov_fundamental.py
@@ -500,11 +500,17 @@ def get_standard_indicator_names():
 
 
 def get_annual_indicator_names():
-    annual_indicator_names = []
+    # Convert GLOBAL_ANNUAL_US_GAAPS to a set for O(1) membership checking
+    global_annual_us_gaaps_set = set(GLOBAL_ANNUAL_US_GAAPS)
 
+    annual_indicator_names = []
     for indicator_name, indicator_data in GLOBAL_INDICATORS.items():
         facts = indicator_data.get('facts', [])
-        if all(fact in GLOBAL_ANNUAL_US_GAAPS for fact in facts):
+        # Use set.issubset for efficient check if all facts are in annual US GAAPS
+        if not facts:
+            # If facts is empty, all(fact in ...) is True; preserve original logic
+            annual_indicator_names.append(indicator_name)
+        elif set(facts).issubset(global_annual_us_gaaps_set):
             annual_indicator_names.append(indicator_name)
 
     return annual_indicator_names

--- a/qnt/data/secgov_fundamental.py
+++ b/qnt/data/secgov_fundamental.py
@@ -508,7 +508,6 @@ def get_annual_indicator_names():
         facts = indicator_data.get('facts', [])
         # Use set.issubset for efficient check if all facts are in annual US GAAPS
         if not facts:
-            # If facts is empty, all(fact in ...) is True; preserve original logic
             annual_indicator_names.append(indicator_name)
         elif set(facts).issubset(global_annual_us_gaaps_set):
             annual_indicator_names.append(indicator_name)

--- a/qnt/data/secgov_fundamental.py
+++ b/qnt/data/secgov_fundamental.py
@@ -505,7 +505,6 @@ def get_annual_indicator_names():
     annual_indicator_names = []
     for indicator_name, indicator_data in GLOBAL_INDICATORS.items():
         facts = indicator_data.get('facts', [])
-        # Use set.issubset for efficient check if all facts are in annual US GAAPS
         if not facts:
             annual_indicator_names.append(indicator_name)
         elif set(facts).issubset(global_annual_us_gaaps_set):

--- a/qnt/data/secgov_fundamental.py
+++ b/qnt/data/secgov_fundamental.py
@@ -500,7 +500,6 @@ def get_standard_indicator_names():
 
 
 def get_annual_indicator_names():
-    # Convert GLOBAL_ANNUAL_US_GAAPS to a set for O(1) membership checking
     global_annual_us_gaaps_set = set(GLOBAL_ANNUAL_US_GAAPS)
 
     annual_indicator_names = []


### PR DESCRIPTION
<!-- CODEFLASH_OPTIMIZATION: {"function":"get_annual_indicator_names","file":"qnt/data/secgov_fundamental.py","speedup_pct":"33%","speedup_x":"0.33x","original_runtime":"693 microseconds","best_runtime":"522 microseconds","optimization_type":"loop","timestamp":"2025-10-10T00:42:06.417Z","version":"1.0"} -->
#### 📄 33% (0.33x) speedup for ***`get_annual_indicator_names` in `qnt/data/secgov_fundamental.py`***

⏱️ Runtime : **`693 microseconds`** **→** **`522 microseconds`** (best of `173` runs)

#### 📝 Explanation and details


The optimized code achieves a **32% speedup** by converting the membership testing from O(N*M) to O(1) lookups and using more efficient set operations.

**Key optimizations:**

1. **Set conversion for O(1) lookups**: Converts `GLOBAL_ANNUAL_US_GAAPS` (a list) to a set once at the beginning. This changes each `fact in GLOBAL_ANNUAL_US_GAAPS` lookup from O(M) list scanning to O(1) hash table lookup, where M is the size of the GAAP list (~23 elements).

2. **Set subset operation**: Replaces the generator expression `all(fact in GLOBAL_ANNUAL_US_GAAPS for fact in facts)` with `set(facts).issubset(global_annual_us_gaaps_set)`. This leverages optimized C-level set operations instead of Python loops.

3. **Empty facts handling**: Explicitly handles the edge case where `facts` is empty to preserve the original logic (empty facts should be included, as `all()` on empty iterables returns `True`).

**Why this works:**
The original code performed ~69% of its time (2.02ms out of 2.94ms total) on the membership checking line. With 1,240 indicators tested and potentially multiple facts per indicator, the O(N*M) complexity of repeated list lookups became the bottleneck. Set operations are implemented in C and highly optimized for these exact use cases.

**Test case performance:**
The optimization shows consistent 15-45% improvements across all test scenarios, with the largest gains (35-45%) occurring in edge cases with empty facts or when the GAAPS list is cleared, suggesting the set conversion overhead is minimal compared to the lookup savings.



✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **49 Passed** |
| 🌀 Generated Regression Tests | ✅ **39 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests and Runtime</summary>



</details>

<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
import copy

# imports
import pytest
from qnt.data.secgov_fundamental import get_annual_indicator_names

# --- Function to test and its dependencies ---

# Dummy build functions, as the test does not invoke them
def build_revenues(): pass
def build_liabilities(): pass
def build_assets(): pass
def build_equity(): pass
def build_net_income(): pass
def build_short_term_investments(): pass
def build_cash_and_cash_equivalents(): pass
def build_cash_and_cash_equivalents_full(): pass
def build_operating_income(): pass
def build_income_before_taxes(): pass
def build_income_before_income_taxes(): pass
def build_depreciation_and_amortization(): pass
def build_interest_net(): pass
def build_income_interest(): pass
def build_interest_expense(): pass
def build_interest_expense_debt(): pass
def build_interest_expense_capital_lease(): pass
def build_interest_income_expense_net(): pass
def build_losses_on_extinguishment_of_debt(): pass
def build_nonoperating_income_expense(): pass
def build_other_nonoperating_income_expense(): pass
def build_debt(): pass
def build_net_debt(): pass
def build_eps(): pass
def build_shares(): pass
def build_ebitda_use_income_before_taxes(): pass
def build_ebitda_use_operating_income(): pass
def build_ebitda_simple(): pass
def build_liabilities_divide_by_ebitda(): pass
def build_net_debt_divide_by_ebitda(): pass
def build_roe(): pass

GLOBAL_ANNUAL_US_GAAPS = [
    'us-gaap:GainsLossesOnExtinguishmentOfDebt',
    'us-gaap:Assets',
    'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
    'us-gaap:StockholdersEquity',
    'us-gaap:LongTermDebtAndCapitalLeaseObligationsCurrent',
    'us-gaap:LongTermDebtAndCapitalLeaseObligations',
    'us-gaap:ShortTermBorrowings',
    'us-gaap:FinanceLeaseLiabilityCurrent',
    'us-gaap:FinanceLeaseLiabilityNoncurrent',
    'us-gaap:LongTermDebtCurrent',
    'us-gaap:LongTermDebtNoncurrent',
    'us-gaap:CapitalLeaseObligationsCurrent',
    'us-gaap:CapitalLeaseObligationsNoncurrent',
    'us-gaap:OperatingLeaseLiabilityCurrent',
    'us-gaap:OperatingLeaseLiabilityNoncurrent',
    'us-gaap:CommercialPaper',
    'us-gaap:CashAndCashEquivalentsAtCarryingValue',
    'us-gaap:ShortTermInvestments',
    'us-gaap:AvailableForSaleSecuritiesCurrent',
    'us-gaap:MarketableSecuritiesCurrent',
    'us-gaap:Liabilities',
    'us-gaap:LiabilitiesAndStockholdersEquity',
    'dei:EntityCommonStockSharesOutstanding'
]

FACT_GROUPS = {
    'debt': [
        'us-gaap:LongTermDebtAndCapitalLeaseObligations',
        'us-gaap:LongTermDebtAndCapitalLeaseObligationsCurrent',
        'us-gaap:LongTermDebtCurrent',
        'us-gaap:LongTermDebtNoncurrent',
        'us-gaap:CapitalLeaseObligationsCurrent',
        'us-gaap:CapitalLeaseObligationsNoncurrent',
        'us-gaap:FinanceLeaseLiabilityCurrent',
        'us-gaap:FinanceLeaseLiabilityNoncurrent',
        'us-gaap:OperatingLeaseLiabilityCurrent',
        'us-gaap:OperatingLeaseLiabilityNoncurrent',
        'us-gaap:ShortTermBorrowings',
        'us-gaap:CommercialPaper',
    ],
    'cash_equivalents': [
        'us-gaap:CashAndCashEquivalentsAtCarryingValue',
        'us-gaap:ShortTermInvestments',
        'us-gaap:AvailableForSaleSecuritiesCurrent',
        'us-gaap:MarketableSecuritiesCurrent',
    ],
    'ebitda': [
        'us-gaap:OperatingIncomeLoss',
        'us-gaap:DepreciationAndAmortization',
        'us-gaap:DepreciationAmortizationAndAccretionNet',
        'us-gaap:DepreciationDepletionAndAmortization',
        'us-gaap:Depreciation',
        'us-gaap:AmortizationOfIntangibleAssets',
    ],
    'shares': ['dei:EntityCommonStockSharesOutstanding'],
    'equity': [
        'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
        'us-gaap:StockholdersEquity',
    ],
    'income': [
        'us-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments',
        'us-gaap:NetIncomeLoss',
        'us-gaap:IncomeTaxExpenseBenefit'
    ],
    'interest': [
        'us-gaap:InvestmentIncomeInterest',
        'us-gaap:InterestExpense',
        'us-gaap:InterestIncomeExpenseNet'
    ],
    'depreciation_and_amortization': [
        'us-gaap:DepreciationAndAmortization',
        'us-gaap:DepreciationAmortizationAndAccretionNet',
        'us-gaap:DepreciationDepletionAndAmortization',
        'us-gaap:Depreciation',
        'us-gaap:AmortizationOfIntangibleAssets'
    ],
}

GLOBAL_INDICATORS = {
    'total_revenue': {'facts': ['us-gaap:Revenues'],
                      'build': build_revenues},

    'liabilities': {'facts': FACT_GROUPS['equity'] + ['us-gaap:Liabilities',
                                                      'us-gaap:LiabilitiesAndStockholdersEquity'],
                    'build': build_liabilities},

    'assets': {'facts': ['us-gaap:Assets'],
               'build': build_assets},

    'equity': {'facts': FACT_GROUPS['equity'],
               'build': build_equity},

    'net_income': {'facts': ['us-gaap:NetIncomeLoss'],
                   'build': build_net_income},

    'short_term_investments': {'facts': [
        'us-gaap:ShortTermInvestments',
    ],
        'build': build_short_term_investments},

    'cash_and_cash_equivalents': {'facts': [
        'us-gaap:CashAndCashEquivalentsAtCarryingValue',
    ],
        'build': build_cash_and_cash_equivalents},

    'cash_and_cash_equivalents_full': {'facts': FACT_GROUPS['cash_equivalents'],
                                       'build': build_cash_and_cash_equivalents_full},

    'operating_income': {'facts': [
        'us-gaap:OperatingIncomeLoss'],
        'build': build_operating_income},

    'income_before_taxes': {'facts': FACT_GROUPS['income'],
                            'build': build_income_before_taxes},

    'income_before_income_taxes': {'facts': [
        'us-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest'],
        'build': build_income_before_income_taxes},

    'depreciation_and_amortization': {'facts': FACT_GROUPS['depreciation_and_amortization'],
                                      'build': build_depreciation_and_amortization},

    'interest_net': {'facts': FACT_GROUPS['income'] + [
        'us-gaap:OperatingIncomeLoss'
    ],
                     'build': build_interest_net},

    'income_interest': {'facts': [
        'us-gaap:InvestmentIncomeInterest',
    ],
        'build': build_income_interest},

    'interest_expense': {'facts': [
        'us-gaap:InterestExpense',
    ],
        'build': build_interest_expense},

    'interest_expense_debt': {'facts': [
        'us-gaap:InterestExpenseDebt',
    ],
        'build': build_interest_expense_debt},
    'interest_expense_capital_lease': {'facts': [
        'us-gaap:InterestExpenseLesseeAssetsUnderCapitalLease',
    ],
        'build': build_interest_expense_capital_lease},

    'interest_income_expense_net': {'facts': [
        'us-gaap:InterestIncomeExpenseNet',
    ],
        'build': build_interest_income_expense_net},

    'losses_on_extinguishment_of_debt': {'facts': [
        'us-gaap:GainsLossesOnExtinguishmentOfDebt',
    ],
        'build': build_losses_on_extinguishment_of_debt},

    'nonoperating_income_expense': {'facts': [
        'us-gaap:NonoperatingIncomeExpense',
    ],
        'build': build_nonoperating_income_expense},

    'other_nonoperating_income_expense': {'facts': [
        'us-gaap:OtherNonoperatingIncomeExpense',
    ],
        'build': build_other_nonoperating_income_expense},

    'debt': {
        'facts': FACT_GROUPS['debt'],
        'build': build_debt,
    },
    'net_debt': {
        'facts': FACT_GROUPS['debt'] + FACT_GROUPS['cash_equivalents'],
        'build': build_net_debt,
    },
    'eps': {
        'facts': [
            'us-gaap:EarningsPerShareDiluted',
            'us-gaap:EarningsPerShare'
        ],
        'build': build_eps,
    },
    'shares': {
        'facts': FACT_GROUPS['shares'],
        'build': build_shares,
    },
    'ebitda_use_income_before_taxes': {
        'facts': FACT_GROUPS['income'] + FACT_GROUPS['interest'] + FACT_GROUPS['ebitda'],
        'build': build_ebitda_use_income_before_taxes,
    },
    'ebitda_use_operating_income': {
        'facts': FACT_GROUPS['ebitda'] + [
            'us-gaap:NonoperatingIncomeExpense',
            'us-gaap:GainsLossesOnExtinguishmentOfDebt',
            'us-gaap:InvestmentIncomeInterest',
        ] + FACT_GROUPS['interest'],
        'build': build_ebitda_use_operating_income,
    },

    'ebitda_simple': {'facts': FACT_GROUPS['depreciation_and_amortization'] + [
        'us-gaap:OperatingIncomeLoss',
    ],
                      'build': build_ebitda_simple},

    'liabilities_divide_by_ebitda': {
        'facts': FACT_GROUPS['ebitda'] + [
            'us-gaap:Liabilities',
            'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
            'us-gaap:StockholdersEquity',
            'us-gaap:LiabilitiesAndStockholdersEquity'
        ] + FACT_GROUPS['cash_equivalents'],
        'build': build_liabilities_divide_by_ebitda
    },

    'net_debt_divide_by_ebitda': {
        'facts': FACT_GROUPS['ebitda'] + FACT_GROUPS['debt'] + FACT_GROUPS['cash_equivalents'],
        'build': build_net_debt_divide_by_ebitda
    },

    'roe': {'facts': [
        'us-gaap:NetIncomeLoss',
        'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
        'us-gaap:StockholdersEquity'
    ],
        'build': build_roe},
}
from qnt.data.secgov_fundamental import get_annual_indicator_names

# --- 1. Basic Test Cases ---

def test_returns_list_type():
    # Should always return a list
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 20.3μs -> 17.5μs (15.8% faster)

def test_single_indicator_all_facts_in_gaaps():
    # Add a custom indicator with all facts in GAAPS
    GLOBAL_INDICATORS['test_indicator'] = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    GLOBAL_ANNUAL_US_GAAPS.append('us-gaap:Assets')
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.9μs -> 14.3μs (25.2% faster)

def test_single_indicator_some_facts_not_in_gaaps():
    # Add a custom indicator with one fact not in GAAPS
    GLOBAL_INDICATORS['test_indicator'] = {'facts': ['us-gaap:Assets', 'us-gaap:NotInGaap'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.5μs -> 13.5μs (29.7% faster)

def test_multiple_indicators_mixed_facts():
    # Add two indicators, one with valid facts, one with invalid
    GLOBAL_INDICATORS['valid'] = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    GLOBAL_INDICATORS['invalid'] = {'facts': ['us-gaap:NotInGaap'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.3μs -> 13.0μs (32.8% faster)

def test_indicator_with_no_facts():
    # Indicator with empty facts should be included (vacuously true)
    GLOBAL_INDICATORS['empty_facts'] = {'facts': [], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.2μs -> 12.6μs (36.8% faster)

def test_indicator_with_duplicate_facts():
    # Duplicates in facts should not affect inclusion
    GLOBAL_INDICATORS['duplicate_facts'] = {'facts': ['us-gaap:Assets', 'us-gaap:Assets'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.9μs -> 12.4μs (36.1% faster)

# --- 2. Edge Test Cases ---

def test_empty_global_indicators():
    # No indicators should yield empty list
    GLOBAL_INDICATORS.clear()
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.2μs -> 12.3μs (40.5% faster)

def test_empty_global_annual_us_gaaps():
    # No facts in GAAPS: only indicators with no facts should be included
    GLOBAL_ANNUAL_US_GAAPS.clear()
    GLOBAL_INDICATORS['no_facts'] = {'facts': [], 'build': lambda: None}
    GLOBAL_INDICATORS['has_facts'] = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.0μs -> 12.6μs (35.0% faster)

def test_indicator_with_fact_not_in_gaaps_and_empty_gaaps():
    # If GAAPS is empty, indicator with facts should not be included
    GLOBAL_ANNUAL_US_GAAPS.clear()
    GLOBAL_INDICATORS['some_facts'] = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.8μs -> 12.2μs (36.8% faster)

def test_indicator_with_non_string_facts():
    # Facts can be non-strings, should be compared as-is
    GLOBAL_INDICATORS['non_string_fact'] = {'facts': [42], 'build': lambda: None}
    GLOBAL_ANNUAL_US_GAAPS.append(42)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.7μs -> 11.8μs (41.4% faster)

def test_indicator_with_none_facts_key():
    # If 'facts' key is missing, default to []
    GLOBAL_INDICATORS['no_facts_key'] = {'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.7μs -> 12.1μs (38.3% faster)

def test_indicator_with_facts_key_none():
    # If 'facts' is None, treat as []
    GLOBAL_INDICATORS['facts_none'] = {'facts': None, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.7μs -> 12.0μs (39.0% faster)


def test_indicator_with_facts_as_tuple():
    # If 'facts' is a tuple, should work if all elements in GAAPS
    GLOBAL_INDICATORS['facts_tuple'] = {'facts': ('us-gaap:Assets',), 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 20.3μs -> 16.9μs (20.2% faster)

def test_indicator_with_facts_as_set():
    # If 'facts' is a set, should work if all elements in GAAPS
    GLOBAL_INDICATORS['facts_set'] = {'facts': {'us-gaap:Assets'}, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.8μs -> 14.0μs (27.5% faster)

def test_indicator_with_large_number_of_facts_some_invalid():
    # Large number of facts, one not in GAAPS
    facts = ['us-gaap:Assets'] * 999 + ['not-in-gaap']
    GLOBAL_INDICATORS['large_facts_invalid'] = {'facts': facts, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.6μs -> 13.3μs (32.2% faster)

def test_indicator_with_large_number_of_facts_all_valid():
    # Large number of facts, all in GAAPS
    facts = ['us-gaap:Assets'] * 1000
    GLOBAL_INDICATORS['large_facts_valid'] = {'facts': facts, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.2μs -> 12.7μs (35.8% faster)

# --- 3. Large Scale Test Cases ---

def test_many_indicators_all_valid():
    # 1000 indicators, all facts in GAAPS
    GLOBAL_INDICATORS.clear()
    for i in range(1000):
        GLOBAL_INDICATORS[f'ind_{i}'] = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 19.7μs -> 15.2μs (29.9% faster)
    for i in range(1000):
        pass

def test_many_indicators_half_valid_half_invalid():
    # 500 valid, 500 invalid
    GLOBAL_INDICATORS.clear()
    for i in range(500):
        GLOBAL_INDICATORS[f'valid_{i}'] = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    for i in range(500):
        GLOBAL_INDICATORS[f'invalid_{i}'] = {'facts': ['not-in-gaap'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 19.5μs -> 15.2μs (28.1% faster)
    for i in range(500):
        pass

def test_performance_with_large_gaaps_and_indicators():
    # 1000 GAAPS, 1000 indicators, all valid
    GLOBAL_ANNUAL_US_GAAPS.clear()
    for i in range(1000):
        GLOBAL_ANNUAL_US_GAAPS.append(f'gaap:{i}')
    GLOBAL_INDICATORS.clear()
    for i in range(1000):
        GLOBAL_INDICATORS[f'ind_{i}'] = {'facts': [f'gaap:{i}'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 19.7μs -> 15.4μs (28.1% faster)

def test_performance_with_large_gaaps_and_some_invalid_indicators():
    # 1000 GAAPS, 1000 indicators, half valid, half invalid
    GLOBAL_ANNUAL_US_GAAPS.clear()
    for i in range(1000):
        GLOBAL_ANNUAL_US_GAAPS.append(f'gaap:{i}')
    GLOBAL_INDICATORS.clear()
    for i in range(500):
        GLOBAL_INDICATORS[f'valid_{i}'] = {'facts': [f'gaap:{i}'], 'build': lambda: None}
    for i in range(500):
        GLOBAL_INDICATORS[f'invalid_{i}'] = {'facts': ['not-in-gaap'], 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 19.7μs -> 15.5μs (26.7% faster)
    for i in range(500):
        pass

def test_large_facts_list_with_all_valid_and_one_invalid_at_end():
    # 999 valid, 1 invalid at the end
    facts = [f'gaap:{i}' for i in range(999)] + ['not-in-gaap']
    GLOBAL_ANNUAL_US_GAAPS.clear()
    GLOBAL_ANNUAL_US_GAAPS.extend([f'gaap:{i}' for i in range(999)])
    GLOBAL_INDICATORS.clear()
    GLOBAL_INDICATORS['test'] = {'facts': facts, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 19.3μs -> 14.9μs (29.2% faster)

def test_large_facts_list_with_all_valid_and_one_invalid_at_start():
    # 1 invalid at start, 999 valid
    facts = ['not-in-gaap'] + [f'gaap:{i}' for i in range(999)]
    GLOBAL_ANNUAL_US_GAAPS.clear()
    GLOBAL_ANNUAL_US_GAAPS.extend([f'gaap:{i}' for i in range(999)])
    GLOBAL_INDICATORS.clear()
    GLOBAL_INDICATORS['test'] = {'facts': facts, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 18.2μs -> 13.9μs (30.8% faster)

def test_large_facts_list_with_all_valid():
    # 1000 valid facts
    facts = [f'gaap:{i}' for i in range(1000)]
    GLOBAL_ANNUAL_US_GAAPS.clear()
    GLOBAL_ANNUAL_US_GAAPS.extend(facts)
    GLOBAL_INDICATORS.clear()
    GLOBAL_INDICATORS['test'] = {'facts': facts, 'build': lambda: None}
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.5μs -> 13.2μs (33.0% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
import pytest
from qnt.data.secgov_fundamental import get_annual_indicator_names


# --- DUMMY BUILD FUNCTIONS (to allow GLOBAL_INDICATORS to be defined) ---
def build_revenues(): pass
def build_liabilities(): pass
def build_assets(): pass
def build_equity(): pass
def build_net_income(): pass
def build_short_term_investments(): pass
def build_cash_and_cash_equivalents(): pass
def build_cash_and_cash_equivalents_full(): pass
def build_operating_income(): pass
def build_income_before_taxes(): pass
def build_income_before_income_taxes(): pass
def build_depreciation_and_amortization(): pass
def build_interest_net(): pass
def build_income_interest(): pass
def build_interest_expense(): pass
def build_interest_expense_debt(): pass
def build_interest_expense_capital_lease(): pass
def build_interest_income_expense_net(): pass
def build_losses_on_extinguishment_of_debt(): pass
def build_nonoperating_income_expense(): pass
def build_other_nonoperating_income_expense(): pass
def build_debt(): pass
def build_net_debt(): pass
def build_eps(): pass
def build_shares(): pass
def build_ebitda_use_income_before_taxes(): pass
def build_ebitda_use_operating_income(): pass
def build_ebitda_simple(): pass
def build_liabilities_divide_by_ebitda(): pass
def build_net_debt_divide_by_ebitda(): pass
def build_roe(): pass

# --- CONSTANTS AND GLOBALS ---

GLOBAL_ANNUAL_US_GAAPS = [
    'us-gaap:GainsLossesOnExtinguishmentOfDebt',
    'us-gaap:Assets',
    'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
    'us-gaap:StockholdersEquity',
    'us-gaap:LongTermDebtAndCapitalLeaseObligationsCurrent',
    'us-gaap:LongTermDebtAndCapitalLeaseObligations',
    'us-gaap:ShortTermBorrowings',
    'us-gaap:FinanceLeaseLiabilityCurrent',
    'us-gaap:FinanceLeaseLiabilityNoncurrent',
    'us-gaap:LongTermDebtCurrent',
    'us-gaap:LongTermDebtNoncurrent',
    'us-gaap:CapitalLeaseObligationsCurrent',
    'us-gaap:CapitalLeaseObligationsNoncurrent',
    'us-gaap:OperatingLeaseLiabilityCurrent',
    'us-gaap:OperatingLeaseLiabilityNoncurrent',
    'us-gaap:CommercialPaper',
    'us-gaap:CashAndCashEquivalentsAtCarryingValue',
    'us-gaap:ShortTermInvestments',
    'us-gaap:AvailableForSaleSecuritiesCurrent',
    'us-gaap:MarketableSecuritiesCurrent',
    'us-gaap:Liabilities',
    'us-gaap:LiabilitiesAndStockholdersEquity',
    'dei:EntityCommonStockSharesOutstanding'
]

FACT_GROUPS = {
    'debt': [
        'us-gaap:LongTermDebtAndCapitalLeaseObligations',
        'us-gaap:LongTermDebtAndCapitalLeaseObligationsCurrent',
        'us-gaap:LongTermDebtCurrent',
        'us-gaap:LongTermDebtNoncurrent',
        'us-gaap:CapitalLeaseObligationsCurrent',
        'us-gaap:CapitalLeaseObligationsNoncurrent',
        'us-gaap:FinanceLeaseLiabilityCurrent',
        'us-gaap:FinanceLeaseLiabilityNoncurrent',
        'us-gaap:OperatingLeaseLiabilityCurrent',
        'us-gaap:OperatingLeaseLiabilityNoncurrent',
        'us-gaap:ShortTermBorrowings',
        'us-gaap:CommercialPaper',
    ],
    'cash_equivalents': [
        'us-gaap:CashAndCashEquivalentsAtCarryingValue',
        'us-gaap:ShortTermInvestments',
        'us-gaap:AvailableForSaleSecuritiesCurrent',
        'us-gaap:MarketableSecuritiesCurrent',
    ],
    'ebitda': [
        'us-gaap:OperatingIncomeLoss',
        'us-gaap:DepreciationAndAmortization',
        'us-gaap:DepreciationAmortizationAndAccretionNet',
        'us-gaap:DepreciationDepletionAndAmortization',
        'us-gaap:Depreciation',
        'us-gaap:AmortizationOfIntangibleAssets',
    ],
    'shares': ['dei:EntityCommonStockSharesOutstanding'],
    'equity': [
        'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
        'us-gaap:StockholdersEquity',
    ],
    'income': [
        'us-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments',
        'us-gaap:NetIncomeLoss',
        'us-gaap:IncomeTaxExpenseBenefit'
    ],
    'interest': [
        'us-gaap:InvestmentIncomeInterest',
        'us-gaap:InterestExpense',
        'us-gaap:InterestIncomeExpenseNet'
    ],
    'depreciation_and_amortization': [
        'us-gaap:DepreciationAndAmortization',
        'us-gaap:DepreciationAmortizationAndAccretionNet',
        'us-gaap:DepreciationDepletionAndAmortization',
        'us-gaap:Depreciation',
        'us-gaap:AmortizationOfIntangibleAssets'
    ],
}

GLOBAL_INDICATORS = {
    'total_revenue': {'facts': ['us-gaap:Revenues'],
                      'build': build_revenues},

    'liabilities': {'facts': FACT_GROUPS['equity'] + ['us-gaap:Liabilities',
                                                      'us-gaap:LiabilitiesAndStockholdersEquity'],
                    'build': build_liabilities},

    'assets': {'facts': ['us-gaap:Assets'],
               'build': build_assets},

    'equity': {'facts': FACT_GROUPS['equity'],
               'build': build_equity},

    'net_income': {'facts': ['us-gaap:NetIncomeLoss'],
                   'build': build_net_income},

    'short_term_investments': {'facts': [
        'us-gaap:ShortTermInvestments',
    ],
        'build': build_short_term_investments},

    'cash_and_cash_equivalents': {'facts': [
        'us-gaap:CashAndCashEquivalentsAtCarryingValue',
    ],
        'build': build_cash_and_cash_equivalents},

    'cash_and_cash_equivalents_full': {'facts': FACT_GROUPS['cash_equivalents'],
                                       'build': build_cash_and_cash_equivalents_full},

    'operating_income': {'facts': [
        'us-gaap:OperatingIncomeLoss'],
        'build': build_operating_income},

    'income_before_taxes': {'facts': FACT_GROUPS['income'],
                            'build': build_income_before_taxes},

    'income_before_income_taxes': {'facts': [
        'us-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest'],
        'build': build_income_before_income_taxes},

    'depreciation_and_amortization': {'facts': FACT_GROUPS['depreciation_and_amortization'],
                                      'build': build_depreciation_and_amortization},

    'interest_net': {'facts': FACT_GROUPS['income'] + [
        'us-gaap:OperatingIncomeLoss'
    ],
                     'build': build_interest_net},

    'income_interest': {'facts': [
        'us-gaap:InvestmentIncomeInterest',
    ],
        'build': build_income_interest},

    'interest_expense': {'facts': [
        'us-gaap:InterestExpense',
    ],
        'build': build_interest_expense},

    'interest_expense_debt': {'facts': [
        'us-gaap:InterestExpenseDebt',
    ],
        'build': build_interest_expense_debt},
    'interest_expense_capital_lease': {'facts': [
        'us-gaap:InterestExpenseLesseeAssetsUnderCapitalLease',
    ],
        'build': build_interest_expense_capital_lease},

    'interest_income_expense_net': {'facts': [
        'us-gaap:InterestIncomeExpenseNet',
    ],
        'build': build_interest_income_expense_net},

    'losses_on_extinguishment_of_debt': {'facts': [
        'us-gaap:GainsLossesOnExtinguishmentOfDebt',
    ],
        'build': build_losses_on_extinguishment_of_debt},

    'nonoperating_income_expense': {'facts': [
        'us-gaap:NonoperatingIncomeExpense',
    ],
        'build': build_nonoperating_income_expense},

    'other_nonoperating_income_expense': {'facts': [
        'us-gaap:OtherNonoperatingIncomeExpense',
    ],
        'build': build_other_nonoperating_income_expense},

    'debt': {
        'facts': FACT_GROUPS['debt'],
        'build': build_debt,
    },
    'net_debt': {
        'facts': FACT_GROUPS['debt'] + FACT_GROUPS['cash_equivalents'],
        'build': build_net_debt,
    },
    'eps': {
        'facts': [
            'us-gaap:EarningsPerShareDiluted',
            'us-gaap:EarningsPerShare'
        ],
        'build': build_eps,
    },
    'shares': {
        'facts': FACT_GROUPS['shares'],
        'build': build_shares,
    },
    'ebitda_use_income_before_taxes': {
        'facts': FACT_GROUPS['income'] + FACT_GROUPS['interest'] + FACT_GROUPS['ebitda'],
        'build': build_ebitda_use_income_before_taxes,
    },
    'ebitda_use_operating_income': {
        'facts': FACT_GROUPS['ebitda'] + [
            'us-gaap:NonoperatingIncomeExpense',
            'us-gaap:GainsLossesOnExtinguishmentOfDebt',
            'us-gaap:InvestmentIncomeInterest',
        ] + FACT_GROUPS['interest'],
        'build': build_ebitda_use_operating_income,
    },

    'ebitda_simple': {'facts': FACT_GROUPS['depreciation_and_amortization'] + [
        'us-gaap:OperatingIncomeLoss',
    ],
                      'build': build_ebitda_simple},

    'liabilities_divide_by_ebitda': {
        'facts': FACT_GROUPS['ebitda'] + [
            'us-gaap:Liabilities',
            'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
            'us-gaap:StockholdersEquity',
            'us-gaap:LiabilitiesAndStockholdersEquity'
        ] + FACT_GROUPS['cash_equivalents'],
        'build': build_liabilities_divide_by_ebitda
    },

    'net_debt_divide_by_ebitda': {
        'facts': FACT_GROUPS['ebitda'] + FACT_GROUPS['debt'] + FACT_GROUPS['cash_equivalents'],
        'build': build_net_debt_divide_by_ebitda
    },

    'roe': {'facts': [
        'us-gaap:NetIncomeLoss',
        'us-gaap:StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest',
        'us-gaap:StockholdersEquity'
    ],
        'build': build_roe},
}
from qnt.data.secgov_fundamental import get_annual_indicator_names

# --- UNIT TESTS ---

# ----------- BASIC TEST CASES -----------

def test_basic_inclusion_and_exclusion():
    """
    Test that the function includes indicators whose facts are all in GLOBAL_ANNUAL_US_GAAPS,
    and excludes those with any fact not present.
    """
    # These indicators should be included (all facts are in GLOBAL_ANNUAL_US_GAAPS)
    expected_included = [
        'liabilities',
        'assets',
        'equity',
        'net_income',
        'short_term_investments',
        'cash_and_cash_equivalents',
        'cash_and_cash_equivalents_full',
        'debt',
        'net_debt',
        'shares',
        'losses_on_extinguishment_of_debt',
    ]
    # These indicators should be excluded (at least one fact not in GLOBAL_ANNUAL_US_GAAPS)
    expected_excluded = [
        'total_revenue',  # 'us-gaap:Revenues' not in GLOBAL_ANNUAL_US_GAAPS
        'operating_income',  # 'us-gaap:OperatingIncomeLoss' not in GLOBAL_ANNUAL_US_GAAPS
        'income_before_taxes',  # 'us-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesMinorityInterestAndIncomeLossFromEquityMethodInvestments' not in GLOBAL_ANNUAL_US_GAAPS
        'income_before_income_taxes',  # 'us-gaap:IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest' not in GLOBAL_ANNUAL_US_GAAPS
        'depreciation_and_amortization',  # All facts not in GLOBAL_ANNUAL_US_GAAPS
        'interest_net',  # At least one fact not in GLOBAL_ANNUAL_US_GAAPS
        'income_interest',  # 'us-gaap:InvestmentIncomeInterest' not in GLOBAL_ANNUAL_US_GAAPS
        'interest_expense',  # 'us-gaap:InterestExpense' not in GLOBAL_ANNUAL_US_GAAPS
        'interest_expense_debt',  # 'us-gaap:InterestExpenseDebt' not in GLOBAL_ANNUAL_US_GAAPS
        'interest_expense_capital_lease',  # 'us-gaap:InterestExpenseLesseeAssetsUnderCapitalLease' not in GLOBAL_ANNUAL_US_GAAPS
        'interest_income_expense_net',  # 'us-gaap:InterestIncomeExpenseNet' not in GLOBAL_ANNUAL_US_GAAPS
        'nonoperating_income_expense',  # 'us-gaap:NonoperatingIncomeExpense' not in GLOBAL_ANNUAL_US_GAAPS
        'other_nonoperating_income_expense',  # 'us-gaap:OtherNonoperatingIncomeExpense' not in GLOBAL_ANNUAL_US_GAAPS
        'eps',  # 'us-gaap:EarningsPerShareDiluted' not in GLOBAL_ANNUAL_US_GAAPS
        'ebitda_use_income_before_taxes',  # All facts not in GLOBAL_ANNUAL_US_GAAPS
        'ebitda_use_operating_income',  # All facts not in GLOBAL_ANNUAL_US_GAAPS
        'ebitda_simple',  # All facts not in GLOBAL_ANNUAL_US_GAAPS
        'liabilities_divide_by_ebitda',  # At least one fact not in GLOBAL_ANNUAL_US_GAAPS
        'net_debt_divide_by_ebitda',  # At least one fact not in GLOBAL_ANNUAL_US_GAAPS
        'roe',  # 'us-gaap:NetIncomeLoss' not in GLOBAL_ANNUAL_US_GAAPS
    ]
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.1μs -> 12.7μs (34.5% faster)
    for name in expected_included:
        pass
    for name in expected_excluded:
        pass

def test_empty_facts_in_indicator(monkeypatch):
    """
    Test that an indicator with an empty facts list is included (vacuously true for 'all').
    """
    # Patch GLOBAL_INDICATORS with a dummy indicator with empty facts
    dummy_indicator = {'facts': [], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_empty_facts', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.0μs -> 12.4μs (37.2% faster)
    # Clean up
    del GLOBAL_INDICATORS['dummy_empty_facts']

def test_indicator_with_one_fact(monkeypatch):
    """
    Test indicator with a single fact that is in GLOBAL_ANNUAL_US_GAAPS.
    """
    dummy_indicator = {'facts': ['us-gaap:Assets'], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_one_fact', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.9μs -> 12.4μs (36.2% faster)
    del GLOBAL_INDICATORS['dummy_one_fact']

def test_indicator_with_one_fact_not_in(monkeypatch):
    """
    Test indicator with a single fact that is NOT in GLOBAL_ANNUAL_US_GAAPS.
    """
    dummy_indicator = {'facts': ['not-a-gaap:RandomFact'], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_one_fact_not_in', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.9μs -> 12.5μs (35.1% faster)
    del GLOBAL_INDICATORS['dummy_one_fact_not_in']

# ----------- EDGE TEST CASES -----------

def test_indicator_with_duplicate_facts(monkeypatch):
    """
    Test indicator with duplicate facts, all in GLOBAL_ANNUAL_US_GAAPS.
    """
    dummy_indicator = {'facts': ['us-gaap:Assets', 'us-gaap:Assets'], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_duplicate_facts', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.0μs -> 12.4μs (37.7% faster)
    del GLOBAL_INDICATORS['dummy_duplicate_facts']

def test_indicator_with_mixed_case_facts(monkeypatch):
    """
    Test that fact name case matters (should be case-sensitive).
    """
    dummy_indicator = {'facts': ['us-gaap:ASSETS'], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_mixed_case', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.0μs -> 12.4μs (36.7% faster)
    del GLOBAL_INDICATORS['dummy_mixed_case']

def test_indicator_with_subset_of_facts(monkeypatch):
    """
    Test that indicator is excluded if any fact is not in GLOBAL_ANNUAL_US_GAAPS.
    """
    dummy_indicator = {'facts': ['us-gaap:Assets', 'not-a-gaap:RandomFact'], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_subset', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.6μs -> 12.7μs (30.6% faster)
    del GLOBAL_INDICATORS['dummy_subset']

def test_indicator_with_none_facts(monkeypatch):
    """
    Test that indicator with facts=None is treated as empty list (should be included).
    """
    dummy_indicator = {'facts': None, 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_none_facts', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.7μs -> 12.4μs (34.7% faster)
    del GLOBAL_INDICATORS['dummy_none_facts']

def test_indicator_with_missing_facts_key(monkeypatch):
    """
    Test that indicator with no 'facts' key is treated as empty list (should be included).
    """
    dummy_indicator = {'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_missing_facts', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.1μs -> 11.8μs (45.1% faster)
    del GLOBAL_INDICATORS['dummy_missing_facts']

def test_indicator_with_empty_string_fact(monkeypatch):
    """
    Test that an indicator with an empty string as a fact is not included.
    """
    dummy_indicator = {'facts': [''], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_empty_string_fact', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 16.9μs -> 12.0μs (41.1% faster)
    del GLOBAL_INDICATORS['dummy_empty_string_fact']

def test_indicator_with_all_facts_empty_strings(monkeypatch):
    """
    Test that an indicator with all facts as empty strings is not included.
    """
    dummy_indicator = {'facts': ['', '', ''], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_all_empty_string_facts', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.0μs -> 12.2μs (39.5% faster)
    del GLOBAL_INDICATORS['dummy_all_empty_string_facts']

def test_indicator_with_facts_as_non_string(monkeypatch):
    """
    Test that an indicator with a non-string fact (e.g. integer) is not included (since it's not in the GAAP list).
    """
    dummy_indicator = {'facts': [123], 'build': lambda: None}
    monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_non_string_fact', dummy_indicator)
    codeflash_output = get_annual_indicator_names(); result = codeflash_output # 17.0μs -> 12.2μs (39.7% faster)
    del GLOBAL_INDICATORS['dummy_non_string_fact']

# ----------- LARGE SCALE TEST CASES -----------

def test_large_number_of_indicators(monkeypatch):
    """
    Test function performance and correctness with a large number of indicators (up to 1000).
    """
    # Backup original
    orig = dict(GLOBAL_INDICATORS)
    try:
        # Add 500 indicators with all facts in GAAP (should be included)
        for i in range(500):
            monkeypatch.setitem(GLOBAL_INDICATORS, f'bulk_included_{i}', {
                'facts': ['us-gaap:Assets', 'us-gaap:Liabilities'],
                'build': lambda: None
            })
        # Add 400 indicators with at least one fact not in GAAP (should NOT be included)
        for i in range(400):
            monkeypatch.setitem(GLOBAL_INDICATORS, f'bulk_excluded_{i}', {
                'facts': ['us-gaap:Assets', f'not-a-gaap:Fact{i}'],
                'build': lambda: None
            })
        # Add 50 indicators with empty facts (should be included)
        for i in range(50):
            monkeypatch.setitem(GLOBAL_INDICATORS, f'bulk_empty_{i}', {
                'facts': [],
                'build': lambda: None
            })
        # Add 50 indicators with facts=None (should be included)
        for i in range(50):
            monkeypatch.setitem(GLOBAL_INDICATORS, f'bulk_none_{i}', {
                'facts': None,
                'build': lambda: None
            })
        codeflash_output = get_annual_indicator_names(); result = codeflash_output
        # All 'bulk_included' and 'bulk_empty' and 'bulk_none' should be present
        for i in range(500):
            pass
        for i in range(50):
            pass
        # All 'bulk_excluded' should NOT be present
        for i in range(400):
            pass
    finally:
        # Restore original
        GLOBAL_INDICATORS.clear()
        GLOBAL_INDICATORS.update(orig)

def test_large_gaap_list(monkeypatch):
    """
    Test with a large GLOBAL_ANNUAL_US_GAAPS list (up to 1000 elements).
    """
    # Backup original
    orig_gaaps = list(GLOBAL_ANNUAL_US_GAAPS)
    try:
        # Add 900 dummy gaaps
        for i in range(900):
            GLOBAL_ANNUAL_US_GAAPS.append(f'us-gaap:DummyFact{i}')
        # Add indicator using only new dummy facts (should be included)
        dummy_indicator = {'facts': [f'us-gaap:DummyFact{i}' for i in range(900)], 'build': lambda: None}
        monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_large_gaap', dummy_indicator)
        codeflash_output = get_annual_indicator_names(); result = codeflash_output
        del GLOBAL_INDICATORS['dummy_large_gaap']
    finally:
        # Restore original
        del GLOBAL_ANNUAL_US_GAAPS[23:]  # Remove the 900 added

def test_large_facts_list(monkeypatch):
    """
    Test an indicator with a large number of facts (up to 1000), all present in GLOBAL_ANNUAL_US_GAAPS.
    """
    # Add 900 dummy gaaps to GLOBAL_ANNUAL_US_GAAPS
    orig_gaaps = list(GLOBAL_ANNUAL_US_GAAPS)
    try:
        for i in range(900):
            GLOBAL_ANNUAL_US_GAAPS.append(f'us-gaap:BigFact{i}')
        # Indicator with 1000 facts, all present
        facts = GLOBAL_ANNUAL_US_GAAPS[:1000]
        dummy_indicator = {'facts': facts, 'build': lambda: None}
        monkeypatch.setitem(GLOBAL_INDICATORS, 'dummy_large_facts', dummy_indicator)
        codeflash_output = get_annual_indicator_names(); result = codeflash_output
        del GLOBAL_INDICATORS['dummy_large_facts']
    finally:
        del GLOBAL_ANNUAL_US_GAAPS[23:]

def test_performance_with_many_facts(monkeypatch):
    """
    Test performance with many indicators, each with many facts (up to 1000 indicators, each with 10 facts).
    """
    # Backup original
    orig = dict(GLOBAL_INDICATORS)
    try:
        # Add 1000 indicators, alternating between all-in and one-out
        for i in range(1000):
            if i % 2 == 0:
                # All facts present
                facts = GLOBAL_ANNUAL_US_GAAPS[:10]
                should_include = True
            else:
                # One fact not present
                facts = GLOBAL_ANNUAL_US_GAAPS[:9] + [f'not-a-gaap:Fact{i}']
                should_include = False
            monkeypatch.setitem(GLOBAL_INDICATORS, f'perf_{i}', {
                'facts': facts,
                'build': lambda: None
            })
        codeflash_output = get_annual_indicator_names(); result = codeflash_output
        for i in range(1000):
            if i % 2 == 0:
                pass
            else:
                pass
    finally:
        GLOBAL_INDICATORS.clear()
        GLOBAL_INDICATORS.update(orig)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


To edit these changes `git checkout codeflash/optimize-get_annual_indicator_names-mgk4g4nl` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)